### PR TITLE
Add support for custom JS prop 

### DIFF
--- a/src/constants/editor/create_quill.ts
+++ b/src/constants/editor/create_quill.ts
@@ -3,7 +3,8 @@ export const create_quill = (
   toolbar: 'false' | string,
   placeholder: string,
   theme: 'snow' | 'bubble',
-  customFonts: Array<string> = []
+  customFonts: Array<string> = [],
+  customJS: string
 ) => {
   let font = '';
   if (customFonts.length > 0) {
@@ -21,7 +22,7 @@ export const create_quill = (
   <script>
   
   ${font}
-  
+  ${customJS}
   var quill = new Quill('#${id}', {
     modules: {
       toolbar: ${toolbar}

--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -41,6 +41,7 @@ export interface EditorProps {
   webview?: WebViewProps;
   onBlur?: () => void;
   onFocus?: () => void;
+  customJS?: string;
 }
 
 export default class QuillEditor extends React.Component<
@@ -112,6 +113,7 @@ export default class QuillEditor extends React.Component<
       customFonts = [],
       customStyles = [],
       defaultFontFamily = undefined,
+      customJS=''
     } = this.props;
 
     return createHtml({
@@ -128,6 +130,7 @@ export default class QuillEditor extends React.Component<
       backgroundColor: theme.background,
       placeholderColor: theme.placeholder,
       customStyles,
+      customJS
     });
   };
 

--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -26,6 +26,7 @@ interface CreateHtmlArgs {
   customStyles: string[];
   fonts: Array<CustomFont>;
   defaultFontFamily?: string;
+  customJS?: string;
 }
 
 const Inital_Args = {
@@ -41,6 +42,7 @@ const Inital_Args = {
   placeholderColor: 'rgba(0,0,0,0.6)',
   customStyles: [],
   fonts: [],
+  customJS:''
 } as CreateHtmlArgs;
 
 export const createHtml = (args: CreateHtmlArgs = Inital_Args) => {
@@ -88,7 +90,8 @@ export const createHtml = (args: CreateHtmlArgs = Inital_Args) => {
     args.toolbar,
     args.placeholder,
     args.theme,
-    args.fonts.map((f) => getFontName(f.name))
+    args.fonts.map((f) => getFontName(f.name)),
+    args.customJS
   )}
   ${editor_js}
   </body>


### PR DESCRIPTION
You can pass Custom JS as String as a prop to allow users to create and Register Blots, modules, and themes. This would also help in integration of additional complex modules like clipboard where custom matchers have to be added and custom themes in future.