### PR TITLE
Fix: Typo in getSelectionJSON payload

### DIFF
--- a/src/constants/editor/editor_js.ts
+++ b/src/constants/editor/editor_js.ts
@@ -109,7 +109,7 @@ export const editor_js = `
   var getSelection = function (key, focus = false) {
     var getSelectionData = quill.getSelection(focus);
     var getSelectionJson = JSON.stringify({
-      type: 'get-selectoin',
+      type: 'get-selection',
       key: key,
       data: getSelectionData });
       sendMessage(getSelectionJson);


### PR DESCRIPTION
I noticed a typo in the getSelection JSON payload.

`type: 'get-selectoin'` => `type: 'get-selection'`