### PR TITLE
feat(quill-editor): allow catching messages using the passed webview props

### DIFF
--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -203,11 +203,11 @@ export default class QuillEditor extends React.Component<
           this._promises = this._promises.filter((x) => x.key !== message.key);
         }
         break;
-    }
-
-    // Allow catching messages using the passed webview props
-    if (this.props.webview?.onMessage) {
-      this.props.webview?.onMessage(event);
+      default:
+        // Allow catching messages using the passed webview props
+        if (this.props.webview?.onMessage) {
+          this.props.webview?.onMessage(event);
+        }
     }
   };
 


### PR DESCRIPTION
Added the possibility to use `webview.onMessage` in case you're injecting custom scripts.
In my case; I expect to use this to check the height of the Quill Editor when the content changes. 🤓 