### PR TITLE
hotfix(types): export DimensionsChangeData

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import type {
   TextChangeData,
   FormatChangeData,
   HtmlChangeData,
+  DimensionsChangeData,
 } from './constants/editor-event';
 export default QuillEditor;
 export { QuillToolbar };
@@ -17,4 +18,5 @@ export type {
   TextChangeData,
   FormatChangeData,
   HtmlChangeData,
+  DimensionsChangeData,
 };


### PR DESCRIPTION
Terribly sorry about this. 😓 
Seem to have forgotten to export the DimensionsChangeData type for the built library.