### PR TITLE
Report dimensions on init and Android focus()

### DIFF
--- a/src/constants/editor/editor_js.ts
+++ b/src/constants/editor/editor_js.ts
@@ -258,6 +258,20 @@ export const editor_js = `
     sendMessage(JSON.stringify({type: 'focus'}));
   });
 
+
+
+  // Report initial dimensions when the editor is instantiated
+  setTimeout(() => {
+    const getDimensionsJson = JSON.stringify({
+      type: 'dimensions-change',
+      data: {
+        width: quill.root.scrollWidth,
+        height: quill.root.scrollHeight
+      }
+    });
+    sendMessage(getDimensionsJson);
+  }, 250)
+
 })(document)
 </script>
 `;

--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -4,7 +4,14 @@ import {
   WebViewMessageEvent,
   WebViewProps,
 } from 'react-native-webview';
-import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  Platform,
+} from 'react-native';
 import { createHtml } from '../utils/editor-utils';
 import type {
   CustomFont,
@@ -233,6 +240,10 @@ export default class QuillEditor extends React.Component<
 
   focus = () => {
     this.post({ command: 'focus' });
+
+    if (Platform.OS === 'android') {
+      this._webview.current?.requestFocus();
+    }
   };
 
   hasFocus = (): Promise<boolean> => {


### PR DESCRIPTION
### Issue
**Calling .focus() on Android does not focus the window**
Specifically requesting focus on the webview seems to allow focus.

---

### Enhancement
**Report dimensions on init**
This is something that enhances developer experience :-) 

Regarding the timeout;
I'd expect new Quill() to be synchronous, but without a timeout wrong dimensions were reported.