### PR TITLE
feat: times symbol for close button

### DIFF
--- a/src/toolbar/components/selection-bar.tsx
+++ b/src/toolbar/components/selection-bar.tsx
@@ -78,7 +78,7 @@ export const SelectionBar: React.FC<Props> = ({}) => {
       </ScrollView>
       <TouchableOpacity onPress={() => hide()}>
         <View style={closeViewStyle}>
-          <Text style={closeTextStyle}>X</Text>
+          <Text style={closeTextStyle}>×</Text>
         </View>
       </TouchableOpacity>
     </View>


### PR DESCRIPTION
Overwrite the `X` symbol by the times symbol `×` for the close button

![image](https://user-images.githubusercontent.com/52027326/184521960-9dc8d577-2cca-4938-b8ff-3e0ba218d551.png)
