### PR TITLE
feat: add setPlaceholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,18 @@ _editor.current.setText('Hello\n');
 
 ---
 
+### `setPlaceholder(text: string)`
+
+Overwrites placeholder with given text.
+
+#### Example:
+
+```
+_editor.current.setPlaceholder('Hello World');
+```
+
+---
+
 ### `updateContents(delta: any)`
 
 Applies Delta to editor contents.

--- a/src/constants/editor/editor_js.ts
+++ b/src/constants/editor/editor_js.ts
@@ -104,6 +104,10 @@ export const editor_js = `
     quill.setText(text);
   }
 
+  var setPlaceholder = function (text) {
+    quill.root.dataset.placeholder = text;
+  }
+
   var updateContents = function (delta) {
     quill.updateContents(delta);
   }
@@ -245,6 +249,9 @@ export const editor_js = `
         break;
       case 'setText':
         setText(msg.text);
+        break;
+      case 'setPlaceholder':
+        setPlaceholder(msg.text);
         break;
       case 'updateContents':
         updateContents(msg.delta);

--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -332,6 +332,10 @@ export default class QuillEditor extends React.Component<
     this.post({ command: 'setText', text });
   };
 
+  setPlaceholder = (text: string) => {
+    this.post({ command: 'setPlaceholder', text });
+  };
+
   updateContents = (delta: any) => {
     this.post({ command: 'updateContents', delta });
   };


### PR DESCRIPTION
The new "setPlaceholder" feature allows you to change or overwrite your placeholder.
This function will be helpful for someone who wants to change placeholder depending on category

For example, using useEffect
```ts
useEffect(() => {
  _editor.current.setPlaceholder(categoryState);
}, [_editor.current, categoryState])
```

Any questions are welcome