### PR TITLE
Remove unnecessary condition

### DIFF
--- a/src/toolbar/quill-toolbar.tsx
+++ b/src/toolbar/quill-toolbar.tsx
@@ -92,7 +92,7 @@ export class QuillToolbar extends Component<QuillToolbarProps, ToolbarState> {
   private prepareIconset = () => {
     const { options, custom } = this.props;
     let toolbarOptions: Array<Array<string | object> | string | object> = [];
-    if (options === 'full' || options === []) {
+    if (options === 'full') {
       toolbarOptions = fullOptions;
     } else if (options === 'basic') {
       toolbarOptions = basicOptions;


### PR DESCRIPTION
```
const a = []
a === [] // This is going to return false always
```
> This condition will always return 'false' since JavaScript compares objects by reference, not value.