### PR TITLE
onMessage never called on android simulator Pixel 6 API 29

### DIFF
--- a/src/constants/editor/editor_js.ts
+++ b/src/constants/editor/editor_js.ts
@@ -1,9 +1,8 @@
 export const editor_js = `
 <script>
 (function (doc) {
-
   var getAttributes = function (node) {
-    const attrArray = node?.attributes ? [...node.attributes] : [];
+    const attrArray = node && node.attributes ? [...node.attributes] : [];
     return attrArray.reduce((_attr, node) => ({ ..._attr, [node.nodeName]: node.nodeValue}), {});
   }
 
@@ -153,7 +152,7 @@ export const editor_js = `
     var getSelectionJson = JSON.stringify({
       type: 'get-selection',
       key: key,
-      data: getSelectionData 
+      data: getSelectionData
     });
     sendMessage(getSelectionJson);
   }
@@ -170,12 +169,12 @@ export const editor_js = `
 
   const getLeaf = function (key, index) {
     const [leaf, offset] = quill.getLeaf(index);
-    const getLeafData = leaf ? {
+    const getLeafData = leaf && leaf.parent && leaf.parent.domNode ? {
       offset,
       text: leaf.text,
       length: leaf.text.length,
       index: quill.getIndex(leaf),
-      attributes: getAttributes(leaf?.parent?.domNode)
+      attributes: getAttributes(leaf.parent.domNode)
     } : null
     const getLeafJson = JSON.stringify({
       type: 'get-leaf',
@@ -242,8 +241,11 @@ export const editor_js = `
       case 'getSelection':
         getSelection(msg.key, msg.focus);
         break;
-      case 'getFormat': 
-        getFormat(msg.key, msg?.index, msg?.length);
+      case 'getFormat':
+        if (msg === undefined || msg.index === undefined || msg.length === undefined) {
+          break;
+        }
+        getFormat(msg.key, msg.index, msg.length);
         break;
       case 'getLeaf':
         getLeaf(msg.key, msg.index);


### PR DESCRIPTION
I found that `onMessage` is never call because of editor_js.ts script contain optional chaining that lead script not be executed