### PR TITLE
feat: support quill 'formats' config

### DIFF
--- a/src/constants/editor/create_quill.ts
+++ b/src/constants/editor/create_quill.ts
@@ -4,6 +4,7 @@ export const create_quill = ({
   clipboard,
   keyboard,
   placeholder,
+  formats,
   theme,
   customFonts = [],
   customJS,
@@ -14,6 +15,7 @@ export const create_quill = ({
   clipboard: string;
   keyboard: string;
   placeholder: string;
+  formats?: string[];
   theme: 'snow' | 'bubble';
   customFonts: Array<string>;
   customJS: string;
@@ -44,13 +46,17 @@ export const create_quill = ({
   <script>
   
   ${font}
-  ${customJS}
+  
   var quill = new Quill('#${id}', {
     modules: { ${modules} },
     placeholder: '${placeholder}',
     theme: '${theme}',
     readOnly: ${readonly},
+    formats: ${!formats ? undefined : JSON.stringify(formats)}
   });
+
+  ${customJS}
+
   </script>
   `;
 };

--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -147,6 +147,7 @@ export default class QuillEditor extends React.Component<
       toolbar: JSON.stringify(quill.modules?.toolbar),
       clipboard: quill.modules?.clipboard,
       keyboard: quill.modules?.keyboard,
+      formats: quill.formats,
       libraries: import3rdParties,
       editorId: quill.id ? quill.id : 'editor-container',
       defaultFontFamily,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,29 @@ export interface QuillConfig {
   };
   theme?: 'snow' | 'bubble';
   placeholder: string;
+  formats?: (
+    | 'background'
+    | 'bold'
+    | 'color'
+    | 'font'
+    | 'code'
+    | 'italic'
+    | 'link'
+    | 'size'
+    | 'strike'
+    | 'script'
+    | 'underline'
+    | 'blockquote'
+    | 'header'
+    | 'indent'
+    | 'list'
+    | 'align'
+    | 'direction'
+    | 'code-block'
+    | 'formula'
+    | 'image'
+    | 'video'
+  )[];
 }
 
 export type StyleFunc = (provided: object) => object;

--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -18,6 +18,7 @@ interface CreateHtmlArgs {
   toolbar: string;
   clipboard?: string;
   keyboard?: string;
+  formats?: string[];
   libraries: 'local' | 'cdn';
   theme: 'snow' | 'bubble';
   editorId: string;
@@ -100,6 +101,7 @@ export const createHtml = (args: CreateHtmlArgs = Inital_Args) => {
     clipboard: args.clipboard ? args.clipboard : '',
     keyboard: args.keyboard ? args.keyboard : '',
     placeholder: args.placeholder,
+    formats: args.formats,
     theme: args.theme,
     customFonts: args.fonts.map((f) => getFontName(f.name)),
     customJS: args.customJS ? args.customJS : '',


### PR DESCRIPTION
This config зкщзукен allows to limit and clear unsupported formatting on copy-paste in the editor