### PR TITLE
Update webview peer dependecy to match >11 versions and allow configuring readonly mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-webview": "^11.0.0"
+    "react-native-webview": ">=11.0.0"
   },
   "jest": {
     "preset": "react-native",

--- a/src/constants/editor/create_quill.ts
+++ b/src/constants/editor/create_quill.ts
@@ -7,6 +7,7 @@ export const create_quill = ({
   theme,
   customFonts = [],
   customJS,
+  readonly = false,
 }: {
   id: string;
   toolbar: 'false' | string;
@@ -16,6 +17,7 @@ export const create_quill = ({
   theme: 'snow' | 'bubble';
   customFonts: Array<string>;
   customJS: string;
+  readonly: boolean;
 }) => {
   let font = '';
   if (customFonts.length > 0) {
@@ -46,7 +48,8 @@ export const create_quill = ({
   var quill = new Quill('#${id}', {
     modules: { ${modules} },
     placeholder: '${placeholder}',
-    theme: '${theme}'
+    theme: '${theme}',
+    readOnly: ${readonly},
   });
   </script>
   `;

--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -59,6 +59,7 @@ export interface EditorProps {
   onBlur?: () => void;
   onFocus?: () => void;
   customJS?: string;
+  readonly?: boolean;
 }
 
 export default class QuillEditor extends React.Component<
@@ -135,6 +136,7 @@ export default class QuillEditor extends React.Component<
       customStyles = [],
       defaultFontFamily = undefined,
       customJS = '',
+      readonly = false,
     } = this.props;
 
     return createHtml({
@@ -155,6 +157,7 @@ export default class QuillEditor extends React.Component<
       placeholderColor: theme.placeholder,
       customStyles,
       customJS,
+      readonly,
     });
   };
 

--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -30,6 +30,7 @@ interface CreateHtmlArgs {
   fonts: Array<CustomFont>;
   defaultFontFamily?: string;
   customJS?: string;
+  readonly?: boolean;
 }
 
 const Inital_Args = {
@@ -49,6 +50,7 @@ const Inital_Args = {
   customStyles: [],
   fonts: [],
   customJS: '',
+  readonly: false,
 } as CreateHtmlArgs;
 
 export const createHtml = (args: CreateHtmlArgs = Inital_Args) => {
@@ -101,6 +103,7 @@ export const createHtml = (args: CreateHtmlArgs = Inital_Args) => {
     theme: args.theme,
     customFonts: args.fonts.map((f) => getFontName(f.name)),
     customJS: args.customJS ? args.customJS : '',
+    readonly: args.readonly ? args.readonly : false,
   })}
   ${editor_js}
   </body>


### PR DESCRIPTION
There is a peer dependency for "react-native-webview": "^11.0.0" which doesn't allow to install library where the library is imported to project which uses >11 react-native-webview version (npm 8+). There is a workaround to use `npm install --legacy-peer-deps` but that is not recommended. 

There is also a change to allow passing `readonly` property which applies `readOnly` mode for quill and the text is not editable. There is existing issue which is related to that topic so I think that will be a good improvement: https://github.com/imnapo/react-native-cn-quill/issues/86