### PR TITLE
fix: set dataDetectorTypes to array with "none" value

### DIFF
--- a/src/editor/quill-editor.tsx
+++ b/src/editor/quill-editor.tsx
@@ -407,7 +407,7 @@ export default class QuillEditor extends React.Component<
       domStorageEnabled={false}
       automaticallyAdjustContentInsets={true}
       bounces={false}
-      dataDetectorTypes="none"
+      dataDetectorTypes={["none"]}
       {...props}
       javaScriptEnabled={true}
       source={{ html: content }}


### PR DESCRIPTION
## Description

This pull request changes dataDetectorTypes to ensure it's always an array `{["none"]}` instead of a string to properly disable all data detectors in the WebView component. This fixes the crash that occurs when `dataDetectorTypes` is defined as a string instead of an array.

## Motivation and Context

This PR fixes issue #146 where users are experiencing the following error:
> Warning: Error: Exception in HostFunction: TypeError: expected dynamic type `array', but had type `string'

This is related to a known issue in react-native-webview (#3662) where using dataDetectorTypes as a string instead of an array causes crashes on New Architecture:
> expecting a dynamic array but receiving a string

Using an array with "none" value for `dataDetectorTypes` explicitly disables all automatic data detection in WebView and ensures type consistency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested the change on:
- [x] iOS
- [x] Android

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The PR description includes appropriate motivation and context